### PR TITLE
fix: reference action repo for labels.json

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,6 +1,14 @@
 name: Labels
 permissions: read-all
-on: [issues, pull_request]
+on: 
+  issues: 
+    types:
+      - opened
+      - labeled
+  pull_request:
+    types:
+      - opened
+      - labeled
 jobs:
   sync-labels:
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.2 (2025-03-14)
+### Bug fixes
+
+- use `labels.json` from action repository
+
 ## 0.0.1 (2025-03-12)
 ### Features
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,6 @@ runs:
     - run: |
         npx github-label-sync \
           --access-token ${{ inputs.access-token }} \
-          --labels labels.json \
+          --labels ${{ github.action_path }}/labels.json \
           ${{ inputs.target-repository }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -16,11 +16,11 @@ runs:
         node-version: 18.x
     - run: npm install -g github-label-sync
       shell: bash
-    - name: Set GitHub Path
-      run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
-      shell: bash
-      env:
-        GITHUB_ACTION_PATH: ${{ github.action_path }}
+    # - name: Set GitHub Path
+    #   run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
+    #   shell: bash
+    #   env:
+    #     GITHUB_ACTION_PATH: ${{ github.action_path }}
     - run: |
         npx github-label-sync \
           --access-token ${{ inputs.access-token }} \

--- a/action.yml
+++ b/action.yml
@@ -16,13 +16,6 @@ runs:
         node-version: 18.x
     - run: npm install -g github-label-sync
       shell: bash
-    # - name: Set GitHub Path
-    #   run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
-    #   shell: bash
-    #   env:
-    #     GITHUB_ACTION_PATH: ${{ github.action_path }}
-    - run: ls
-      shell: bash
     - run: |
         npx github-label-sync \
           --access-token ${{ inputs.access-token }} \

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,8 @@ runs:
     #   shell: bash
     #   env:
     #     GITHUB_ACTION_PATH: ${{ github.action_path }}
+    - run: ls
+      shell: bash
     - run: |
         npx github-label-sync \
           --access-token ${{ inputs.access-token }} \


### PR DESCRIPTION
## Summary

Use `$GITHUB_ACTION_PATH` to access the action's copy of `labels.json`.

## Testing

Ran the action in [outoforbitdev/.github](https://github.com/outoforbitdev/.github/actions/runs/13866748160/job/38807294859)
